### PR TITLE
Add barcode scanner and product detail screens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.expo/

--- a/App.js
+++ b/App.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import ScannerScreen from './screens/ScannerScreen';
+import ProductDetailsScreen from './screens/ProductDetailsScreen';
+
+const Stack = createStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen
+          name="Scanner"
+          component={ScannerScreen}
+          options={{ title: 'Leitor de Código de Barras' }}
+        />
+        <Stack.Screen
+          name="ProductDetails"
+          component={ProductDetailsScreen}
+          options={{ title: 'Detalhes do Produto' }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-Hello World!
+# TarifApp
+
+Aplicativo React Native que realiza a leitura de códigos de barras e exibe detalhes do produto, com foco no país de origem. Também apresenta sugestões de outros produtos relacionados.
+
+## Scripts
+
+- `npm start` - inicia o aplicativo (expo).
+- `npm test` - executa testes (nenhum configurado).

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/components/ProductCard.js
+++ b/components/ProductCard.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+
+export default function ProductCard({ item, onPress }) {
+  return (
+    <TouchableOpacity style={styles.card} onPress={onPress}>
+      <Text style={styles.title}>{item.product_name || item.code}</Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    padding: 12,
+    marginBottom: 8,
+    backgroundColor: '#f9f9f9',
+    borderRadius: 8,
+  },
+  title: {
+    fontSize: 16,
+  },
+});

--- a/hooks/useProductDetails.js
+++ b/hooks/useProductDetails.js
@@ -1,0 +1,31 @@
+import { useState, useEffect } from 'react';
+import { getProduct, getProductsByCategory } from '../services/openFoodFacts';
+
+export default function useProductDetails(barcode) {
+  const [product, setProduct] = useState(null);
+  const [suggestions, setSuggestions] = useState([]);
+
+  useEffect(() => {
+    let isActive = true;
+    async function load() {
+      try {
+        const prod = await getProduct(barcode);
+        if (!isActive) return;
+        setProduct(prod);
+        const category = prod?.categories_tags?.[0];
+        if (category) {
+          const items = await getProductsByCategory(category, 5);
+          if (isActive) setSuggestions(items);
+        }
+      } catch (e) {
+        console.warn(e);
+      }
+    }
+    load();
+    return () => {
+      isActive = false;
+    };
+  }, [barcode]);
+
+  return { product, suggestions };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "tarifapp",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "echo 'No tests specified'"
+  },
+  "dependencies": {
+    "expo": "~48.0.0",
+    "expo-barcode-scanner": "~12.3.0",
+    "react": "18.2.0",
+    "react-native": "0.71.8",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/stack": "^6.3.16"
+  }
+}

--- a/screens/ProductDetailsScreen.js
+++ b/screens/ProductDetailsScreen.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { View, Text, StyleSheet, FlatList } from 'react-native';
+import ProductCard from '../components/ProductCard';
+import useProductDetails from '../hooks/useProductDetails';
+
+export default function ProductDetailsScreen({ route, navigation }) {
+  const { barcode } = route.params;
+  const { product, suggestions } = useProductDetails(barcode);
+
+  if (!product) {
+    return <Text>Carregando...</Text>;
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.name}>{product.product_name}</Text>
+      <Text style={styles.origin}>País de origem: {product.countries || 'Desconhecido'}</Text>
+      <Text style={styles.sectionTitle}>Sugestões</Text>
+      <FlatList
+        data={suggestions}
+        keyExtractor={(item) => item.id || item.code}
+        renderItem={({ item }) => (
+          <ProductCard
+            item={item}
+            onPress={() => navigation.push('ProductDetails', { barcode: item.code })}
+          />
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  name: {
+    fontSize: 22,
+    fontWeight: 'bold',
+    marginBottom: 8,
+  },
+  origin: {
+    fontSize: 16,
+    marginBottom: 16,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 8,
+  },
+});

--- a/screens/ScannerScreen.js
+++ b/screens/ScannerScreen.js
@@ -1,0 +1,46 @@
+import React, { useState, useEffect } from 'react';
+import { Text, View, StyleSheet, Button } from 'react-native';
+import { BarCodeScanner } from 'expo-barcode-scanner';
+
+export default function ScannerScreen({ navigation }) {
+  const [hasPermission, setHasPermission] = useState(null);
+  const [scanned, setScanned] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const { status } = await BarCodeScanner.requestPermissionsAsync();
+      setHasPermission(status === 'granted');
+    })();
+  }, []);
+
+  const handleBarCodeScanned = ({ type, data }) => {
+    setScanned(true);
+    navigation.navigate('ProductDetails', { barcode: data });
+  };
+
+  if (hasPermission === null) {
+    return <Text>Solicitando permissão para câmera...</Text>;
+  }
+  if (hasPermission === false) {
+    return <Text>Sem acesso à câmera</Text>;
+  }
+
+  return (
+    <View style={styles.container}>
+      <BarCodeScanner
+        onBarCodeScanned={scanned ? undefined : handleBarCodeScanned}
+        style={StyleSheet.absoluteFillObject}
+      />
+      {scanned && (
+        <Button title={'Toque para escanear novamente'} onPress={() => setScanned(false)} />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+});

--- a/services/openFoodFacts.js
+++ b/services/openFoodFacts.js
@@ -1,0 +1,13 @@
+export async function getProduct(barcode) {
+  const res = await fetch(`https://world.openfoodfacts.org/api/v0/product/${barcode}.json`);
+  if (!res.ok) throw new Error('Failed to fetch product');
+  const json = await res.json();
+  return json.product;
+}
+
+export async function getProductsByCategory(category, limit = 5) {
+  const res = await fetch(`https://world.openfoodfacts.org/category/${category}.json`);
+  if (!res.ok) throw new Error('Failed to fetch category');
+  const json = await res.json();
+  return json.products?.slice(0, limit) || [];
+}


### PR DESCRIPTION
## Summary
- set up React Native app with Expo and navigation
- add barcode scanner screen
- display product details with origin info and suggestions list
- refactor API calls into services and hook for cleaner data fetching

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68969e1e2f388332a4182cc162a1df84