### PR TITLE
Add loading and error state to product details hook

### DIFF
--- a/hooks/useProductDetails.js
+++ b/hooks/useProductDetails.js
@@ -4,10 +4,14 @@ import { getProduct, getProductsByCategory } from '../services/openFoodFacts';
 export default function useProductDetails(barcode) {
   const [product, setProduct] = useState(null);
   const [suggestions, setSuggestions] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     let isActive = true;
     async function load() {
+      setLoading(true);
+      setError(null);
       try {
         const prod = await getProduct(barcode);
         if (!isActive) return;
@@ -16,9 +20,17 @@ export default function useProductDetails(barcode) {
         if (category) {
           const items = await getProductsByCategory(category, 5);
           if (isActive) setSuggestions(items);
+        } else {
+          if (isActive) setSuggestions([]);
         }
       } catch (e) {
+        if (!isActive) return;
         console.warn(e);
+        setError(e);
+        setProduct(null);
+        setSuggestions([]);
+      } finally {
+        if (isActive) setLoading(false);
       }
     }
     load();
@@ -27,5 +39,5 @@ export default function useProductDetails(barcode) {
     };
   }, [barcode]);
 
-  return { product, suggestions };
+  return { product, suggestions, loading, error };
 }


### PR DESCRIPTION
## Summary
- add loading and error states to useProductDetails hook
- manage loading lifecycle and reset suggestions on error

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896aa680edc833289769c57f533a364