### PR TITLE
Handle OpenFoodFacts product not found status

### DIFF
--- a/services/openFoodFacts.js
+++ b/services/openFoodFacts.js
@@ -2,6 +2,10 @@ export async function getProduct(barcode) {
   const res = await fetch(`https://world.openfoodfacts.org/api/v0/product/${barcode}.json`);
   if (!res.ok) throw new Error('Failed to fetch product');
   const json = await res.json();
+  if (json.status !== 1) {
+    // Product not found
+    return null;
+  }
   return json.product;
 }
 


### PR DESCRIPTION
## Summary
- Return null from getProduct when OpenFoodFacts reports product not found

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896aa543f5c8332ace17ab95ce8303d