### PR TITLE
Allow ngrok host in Vite config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,4 +3,7 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    allowedHosts: ['f5fbe2ecce36.ngrok-free.app'],
+  },
 });


### PR DESCRIPTION
## Summary
- allow the ngrok host `f5fbe2ecce36.ngrok-free.app` in Vite's `server.allowedHosts`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896d4d2c1c08332995e12627c6c7679