### PR TITLE
Allow wildcard ngrok hosts in Vite dev server

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,4 +3,7 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    allowedHosts: ['.ngrok-free.app'],
+  },
 });


### PR DESCRIPTION
## Summary
- configure Vite dev server to allow any `*.ngrok-free.app` subdomain

## Testing
- `npm test`
- `npm run dev` then `curl -I -H "Host: test.ngrok-free.app" http://localhost:5173`

------
https://chatgpt.com/codex/tasks/task_e_6896d71e1aac83329172e0502c20bfe8