### PR TITLE
feat: integrate meta tags and scanner toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .expo/
+dist/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Aplicação web em React para leitura de códigos de barras utilizando a biblioteca ZXing via WebAssembly.
 
+Parte do layout e das metatags foi inspirada no projeto [scan-source-connect](https://github.com/rodrigocnascimento/scan-source-connect), mantendo o componente de leitura de código de barras original.
+
 ## Scripts
 
 - `npm run dev` - inicia o servidor de desenvolvimento (Vite).

--- a/index.html
+++ b/index.html
@@ -3,7 +3,30 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>TarifApp</title>
+    <title>TarifApp - Leitor de Código de Barras</title>
+    <meta
+      name="description"
+      content="Descubra a origem dos produtos escaneando códigos de barras"
+    />
+    <meta name="author" content="TarifApp" />
+
+    <meta property="og:title" content="TarifApp" />
+    <meta
+      property="og:description"
+      content="Descubra a origem dos produtos escaneando códigos de barras"
+    />
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:image"
+      content="https://lovable.dev/opengraph-image-p98pqg.png"
+    />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@lovable_dev" />
+    <meta
+      name="twitter:image"
+      content="https://lovable.dev/opengraph-image-p98pqg.png"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,19 @@
+import { useState } from 'react';
 import BarcodeScanner from './BarcodeScanner';
-
 function App() {
+  const [showScanner, setShowScanner] = useState(false);
+
   return (
     <div>
       <h1>TarifApp</h1>
-      <BarcodeScanner />
+      {showScanner ? (
+        <div>
+          <BarcodeScanner />
+          <button onClick={() => setShowScanner(false)}>Fechar</button>
+        </div>
+      ) : (
+        <button onClick={() => setShowScanner(true)}>Iniciar Escaneamento</button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add metadata inspired by scan-source-connect
- toggle barcode scanner with start/close button
- ignore built assets

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896e86db4b883329a809102002c5571